### PR TITLE
Removing upper limit on Hashie version

### DIFF
--- a/rocket_pants.gemspec
+++ b/rocket_pants.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'actionpack', '>= 3.0', '< 5.0'
   s.add_dependency 'railties',   '>= 3.0', '< 5.0'
   s.add_dependency 'will_paginate', '~> 3.0'
-  s.add_dependency 'hashie',        '>= 1.0', '< 3'
+  s.add_dependency 'hashie',        '>= 1.0'
   s.add_dependency 'api_smith'
   s.add_dependency 'moneta'
   s.add_development_dependency 'rspec',       '>= 2.4', '< 4.0'


### PR DESCRIPTION
This dependency on older versions of Hashie is making it difficult to use this gem.  This Gem needs to be able to support Hashie 3.0 and higher.
